### PR TITLE
LOG: add .csv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dataset
 job_posting.csv
 generate_sample_resume.py
 __pycache__/
+*.csv
+.csv


### PR DESCRIPTION
protects our scm from data files accidentally being uploaded to PRs. data files are best stored in object mediums like s3 or traditional database technologies. tbh we can just use google drive for data files.